### PR TITLE
Add ShizukuProvider to Fix Permission Request Issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,7 +40,14 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
-
+        
+        <provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:multiprocess="false"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
         <activity
             android:name="com.rk.terminal.ui.activities.terminal.MainActivity"
             android:exported="true"


### PR DESCRIPTION
Added ShizukuProvider to AndroidManifest.xml to resolve the issue of the app not requesting Shizuku permissions. The provider is configured with android.permission.INTERACT_ACROSS_USERS_FULL as required.